### PR TITLE
Fix timing issue breaking extension

### DIFF
--- a/src/inject/run-addon.js
+++ b/src/inject/run-addon.js
@@ -1,6 +1,6 @@
 import Localization from "./l10n.js";
 
-// Make sure SA lower than v1.9.0 doesn't run editor-devtools
+// Make sure SA doesn't run editor-devtools
 window.initGUI = true;
 
 const MAIN_JS = "userscript.js";
@@ -89,6 +89,12 @@ const l10nObject = new Localization(getL10NURLs());
 const msg = (key, placeholders) => l10nObject.get(`editor-devtools/${key}`, placeholders);
 msg.locale = langCode;
 
+const isPageReady = () =>
+  // Make sure <title> element exists to make sure Scratch <style>s were injected,
+  // which are necessary for addon.tab.scratchClass() calls.
+  // We also need the stage element to be there to get the VM object.
+  document.querySelector("title") && document.querySelector('div[class^="stage-wrapper_stage-wrapper_"]');
+
 l10nObject.loadByAddonId("editor-devtools").then(() =>
   import(scriptUrl).then((module) => {
     const loaded = () => {
@@ -105,7 +111,18 @@ l10nObject.loadByAddonId("editor-devtools").then(() =>
         safeMsg: (key, placeholders) => l10nObject.escaped(`editor-devtools/${key}`, placeholders),
       });
     };
-    if (document.readyState === "complete") loaded();
-    else window.addEventListener("load", () => loaded(), { once: true });
+    if (isPageReady()) {
+      if (document.readyState === "complete") loaded();
+      else window.addEventListener("load", () => loaded(), { once: true });
+    } else {
+      const observer = new MutationObserver(() => {
+        if (isPageReady()) {
+          if (document.readyState === "complete") loaded();
+          else window.addEventListener("load", () => loaded(), { once: true });
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+    }
   })
 );

--- a/src/run-inject.js
+++ b/src/run-inject.js
@@ -10,18 +10,10 @@ else {
 }
 
 function onHeadAvailable() {
-  // Wait until <title> element exists to make sure Scratch <style>s were injected,
-  // which are necessary for addon.tab.scratchClass() calls.
-  const titleObserver = new MutationObserver(() => {
-    if (document.querySelector("title")) {
-      const script = document.createElement("script");
-      script.id = "devtools-extension-module";
-      script.setAttribute("data-path", chrome.runtime.getURL(""));
-      script.type = "module";
-      script.src = chrome.runtime.getURL("inject/run-addon.js");
-      document.head.appendChild(script);
-      titleObserver.disconnect();
-    }
-  });
-  titleObserver.observe(document.head, { childList: true });
+  const script = document.createElement("script");
+  script.id = "devtools-extension-module";
+  script.setAttribute("data-path", chrome.runtime.getURL(""));
+  script.type = "module";
+  script.src = chrome.runtime.getURL("inject/run-addon.js");
+  document.head.appendChild(script);
 }


### PR DESCRIPTION
I'm not 100% sure, but I think sometimes when loading a project from the player (not loading /editor directly), the window load event is triggered before scratch-www loaded any info about the project. Because of that, there's of course no stage element. So the addon attempts to get the VM, but `document.querySelector('div[class^="stage-wrapper_stage-wrapper_"]')` returns `null` and everything falls apart.
With this PR, we also make sure that element exists before running the addon. I also moved the logic from run-inject.js to run-addon.js that waited for `<title>` to exist (which would mean all `<style>`s needed for `addon.tab.scratchClass()` calls work).
We still wait until the page is "loaded", but the stage wrapper existing is now a third condition for the addon to run.

I also made a comment clearer - Scratch Addons v1.9.x also uses `window.initGUI` to check if the extension is enabled.