### PR TITLE
Sync getL10NURLs function with Scratch Addons

### DIFF
--- a/src/inject/run-addon.js
+++ b/src/inject/run-addon.js
@@ -77,6 +77,9 @@ const langCode = `; ${document.cookie}`.split("; scratchlanguage=").pop().split(
 function getL10NURLs() {
   // Note: not identical to Scratch Addons function
   const urls = [getURL(`l10n/${langCode}`)];
+  if (langCode === "pt") {
+    urls.push(getURL(`addons-l10n/pt-br`));
+  }
   if (langCode.includes("-")) {
     urls.push(getURL(`l10n/${langCode.split("-")[0]}`));
   }


### PR DESCRIPTION
Updates the `getL10NURLs` function along with Scratch Addons. SA stopped using `pt` and started using `pt-br` exclusively.